### PR TITLE
Fix デッキリストへの追加をディープコピーに変更

### DIFF
--- a/src/components/DeckList.vue
+++ b/src/components/DeckList.vue
@@ -134,13 +134,16 @@ export default {
       if(this.decklist.some(element => element.No === card.No)) {
         let card_index = this.decklist.findIndex(element => element.No === card.No);
         let card_in_deck = this.decklist[card_index];
+
         if(card_in_deck.SheetNum < 3) {
           card_in_deck.SheetNum++;
           this.$set(this.decklist, card_index, card_in_deck);
         }
       } else {
-        card["SheetNum"] = 1;
-        this.decklist.push(card);
+        // 渡されたのはcardへの参照なので、Object自体をディープコピー
+        let card_in_deck = Object.assign({}, card);
+        card_in_deck["SheetNum"] = 1;
+        this.decklist.push(card_in_deck);
       }
     },
     removeCard(card) {


### PR DESCRIPTION
デッキリストにカードを追加する際、参照渡しとなっていたため、カード枚数などの変更もカードリスト・デッキリスト・サイドデッキリストで共有されてしまっていた。

JavaScriptの配列とObjectは標準で参照渡しとなるので、`=`ではなく`Object.assign()`を用いて値のディープコピーを行うかたちとした。

値渡しが必要なのは、2つのデッキリスト（メイン・サイド）へのカード追加だけと思われるが、他の部分も要チェック